### PR TITLE
Adding casting from int to enums

### DIFF
--- a/Source/Input/ControllerInput.cpp
+++ b/Source/Input/ControllerInput.cpp
@@ -153,7 +153,7 @@ void ControllerInput::SetConfiguredKey(int action, int key, String controller)
 	data[P_CONTROL_ACTION] = action;
 	data[P_ACTION_NAME] = _controlMapNames[action];
 	data[P_KEY] = key;
-	data[P_KEY_NAME] = input->GetKeyName(key);
+	data[P_KEY_NAME] = input->GetKeyName(static_cast<Key>(key));
 	SendEvent(MyEvents::E_INPUT_MAPPING_FINISHED, data);
 
 	SaveConfig();

--- a/Source/Input/Controllers/JoystickInput.cpp
+++ b/Source/Input/Controllers/JoystickInput.cpp
@@ -53,7 +53,7 @@ void JoystickInput::HandleKeyDown(StringHash eventType, VariantMap& eventData)
         joystick++;
     }
 	auto* input = GetSubsystem<Input>();
-	URHO3D_LOGINFO("Joystick down " + input->GetKeyName(key) + " => " + String(key));
+	URHO3D_LOGINFO("Joystick down " + input->GetKeyName(static_cast<Key>(key)) + " => " + String(key));
 
 	if (_activeAction > 0 && _timer.GetMSec(false) > 100) {
 		auto* controllerInput = GetSubsystem<ControllerInput>();
@@ -77,7 +77,7 @@ void JoystickInput::HandleKeyUp(StringHash eventType, VariantMap& eventData)
         joystick++;
     }
 	auto* input = GetSubsystem<Input>();
-	URHO3D_LOGINFO("Joystick up " + input->GetKeyName(key) + " => " + String(key));
+	URHO3D_LOGINFO("Joystick up " + input->GetKeyName(static_cast<Key>(key)) + " => " + String(key));
 
 	if (_activeAction > 0) {
 		return;

--- a/Source/Input/Controllers/KeyboardInput.cpp
+++ b/Source/Input/Controllers/KeyboardInput.cpp
@@ -64,7 +64,7 @@ String KeyboardInput::GetActionKeyName(int action)
 {
 	if (_mappedControlToKey.Contains(action)) {
 		auto* input = GetSubsystem<Input>();
-		return input->GetKeyName(_mappedControlToKey[action]);
+		return input->GetKeyName(static_cast<Key>(_mappedControlToKey[action]));
 	}
 
 	return String::EMPTY;

--- a/Source/UI/Settings/SettingsWindow.cpp
+++ b/Source/UI/Settings/SettingsWindow.cpp
@@ -87,7 +87,7 @@ void SettingsWindow::SaveVideoSettings()
 	auto* renderer = GetSubsystem<Renderer>();
 	renderer->SetTextureFilterMode(TextureFilterMode(_graphicsSettings.textureFilterMode));
 	renderer->SetTextureAnisotropy(_graphicsSettings.textureAnistropy);
-	renderer->SetTextureQuality(_graphicsSettings.textureQuality);
+	renderer->SetTextureQuality(static_cast<MaterialQuality>(_graphicsSettings.textureQuality));
 	renderer->SetShadowQuality((ShadowQuality)_graphicsSettings.shadowQuality);
 	renderer->SetDrawShadows(_graphicsSettings.shadows);
 


### PR DESCRIPTION
Compiler: MSVC2017 15.7.6
Urho3D version: latest from MASTER branch

I wasn't able to compile the project in MSVC2017 since it complained about functions expecting enums instead of an int. To correct this, I just added static casts from int to whatever enum the functions were expecting. After that, it compiled just fine.